### PR TITLE
Fix for .vimrc under paths containing spaces

### DIFF
--- a/autoload/dirsettings.vim
+++ b/autoload/dirsettings.vim
@@ -91,12 +91,12 @@ function s:ApplyLocalConfiguration(fname, dname, path)
 	let l:fulltagname = a:path . '/' . a:dname . '/tags'
 
 	if (isdirectory(l:fulldname))
-		execute "set runtimepath+=" . l:fulldname
+		execute "set runtimepath+=" . fnameescape(l:fulldname)
 	endif
 	if (filereadable(l:fullfname))
-		exec 'source ' . l:fullfname
+		exec 'source ' . fnameescape(l:fullfname)
 	endif
 	if (filereadable(l:fulltagname))
-		exec 'set tags +=' . l:fulltagname
+		exec 'set tags +=' . fnameescape(l:fulltagname)
 	endif
 endfunction

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-filepath="$(dirname "$(readlink -f "$0")")"
+filepath=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 testdir="${filepath}/tests"
 
 fakehome="${testdir}/data"

--- a/tests/data/space in path/level1/.vimrc
+++ b/tests/data/space in path/level1/.vimrc
@@ -1,0 +1,4 @@
+let g:dirsettingsOverwriteTest="level1"
+let g:dirsettingsLevel1="level1 loaded"
+
+let g:dirsettingsVimRcVariable="set-by-level1"

--- a/tests/src/test010_space_in_path_loaded.msgok
+++ b/tests/src/test010_space_in_path_loaded.msgok
@@ -1,0 +1,5 @@
+
+"../data/space in path/level1/empty" 
+"../data/space in path/level1/empty" 0L, 0C
+level1 loaded
+level1

--- a/tests/src/test010_space_in_path_loaded.vim
+++ b/tests/src/test010_space_in_path_loaded.vim
@@ -1,0 +1,6 @@
+edit ../data/space\ in\ path/level1/empty
+
+echo g:dirsettingsLevel1
+echo g:dirsettingsOverwriteTest
+
+quit!


### PR DESCRIPTION
Bonus: make tests run on OSX.