### PR TITLE
Don't try to source //.vimrc

### DIFF
--- a/autoload/dirsettings.vim
+++ b/autoload/dirsettings.vim
@@ -86,6 +86,9 @@ function s:LoadDirectorySettings(fname, dname, rootpath, home, ...)
 endfunction
 
 function s:ApplyLocalConfiguration(fname, dname, path)
+	if (a:path == '/')
+		return
+	endif
 	let l:fullfname = a:path . '/' . a:fname
 	let l:fulldname = a:path . '/' . a:dname
 	let l:fulltagname = a:path . '/' . a:dname . '/tags'


### PR DESCRIPTION
There appears to be a bug in vim, at least on my system, where for some reason `filereadable('//.vimrc')` returns true even if the file doesn't exist (this seems to be true for any path starting with `//`).

That causes the plugin to crash here when it tries to source a file that should exist but doesn't.  This PR solves the problem by simply not trying to load a `.vimrc` from `/` (which probably shouldn't exist anyways).

Thanks for the excellent plugin--until I stumbled on this it didn't even occur to me how much I needed it.